### PR TITLE
Refactor method insertAtIndex

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -29,7 +29,6 @@ export type NodeFunction<T> = (node: Node<T>) => Node<T>
 export type NodeIndex = number
 export type ListSize = number
 export type MaybeNode<T> = Node<T> | undefined
-export type SideEffect = () => void
 
 // Keeping track of both a head and tail for a cyclical doubly linked list may seem redundant
 // since the tail is just the current head's previous node however;
@@ -88,20 +87,21 @@ export class LinkedList<T> {
 
   // the intention behind this method is to provide baked in iteration in both directions
   // (forward and backward) with a mechanism to execute a user provided side effect
-  // (extensibility principle) in the form of a callback. When the targeted node is found
+  // (for extensibility) in the form of a callback. When the targeted node is found
   // this method will return the application of the callback to the node, if the user does
   // not supply a callback, this method will instead return the targeted node. This method is
   // unique in that if the targeted index is out of bounds, it will return undefined
   iterateThroughList(
     targetIndex: number,
-    sideEffect: NodeFunction<T>,
+    callback?: NodeFunction<T>,
     previousIndex = 0,
     previousNode: Node<T> = this.head
-  ): MaybeNode<T> | SideEffect | Error {
-    if (Math.abs(targetIndex) >= this.size) return
+  ): MaybeNode<T> {
+    // the head should be accessible via a negative index equal to the list size
+    if (targetIndex >= this.size || Math.abs(targetIndex) > this.size) return
 
     if (targetIndex === 0) {
-      return sideEffect ? sideEffect(this.head) : this.head
+      return callback ? callback(this.head) : this.head
     }
 
     let iteration, currentNode
@@ -120,21 +120,19 @@ export class LinkedList<T> {
       case 'increment':
         return this.iterateThroughList(
           targetIndex,
-          sideEffect,
+          callback,
           previousIndex + 1,
           previousNode.next()
         )
       case 'decrement':
         return this.iterateThroughList(
           targetIndex,
-          sideEffect,
+          callback,
           previousIndex - 1,
           previousNode.previous()
         )
-      case 'done':
-        return sideEffect ? sideEffect(currentNode) : currentNode
       default:
-        return new Error('invalid case for iteration')
+        return callback ? callback(currentNode) : currentNode
     }
   }
 

--- a/index.ts
+++ b/index.ts
@@ -31,8 +31,8 @@ export type ListSize = number
 export type MaybeNode<T> = Node<T> | undefined
 
 // Keeping track of both a head and tail for a cyclical doubly linked list may seem redundant
-// since the tail is just the current head's previous node however;
-// when adding new nodes at the head we don't need to iterate through the entire list
+// since the tail is just the current head's previous node however; when adding new nodes at
+// the head we don't need to iterate through the entire list to get the new head's previous
 export class LinkedList<T> {
   constructor(args: LinkedListConstructorArgs<T>) {
     const {head, tail, size} = args
@@ -45,8 +45,8 @@ export class LinkedList<T> {
     const previousHead = this.head
     const newNode: Node<T> = new Node({
       data,
-      next: () => previousHead,
-      previous: () => this.tail,
+      next: previousHead ? () => previousHead : null,
+      previous: this.tail ? () => this.tail : null,
     })
 
     if (this.head) {
@@ -54,11 +54,13 @@ export class LinkedList<T> {
     }
 
     this.head = newNode
+
     if (!this.tail) {
       this.tail = newNode
-    } else {
-      this.tail.next = () => this.head
+      newNode.previous = () => newNode
     }
+
+    this.tail.next = () => this.head
 
     return (this.size += 1)
   }
@@ -67,8 +69,8 @@ export class LinkedList<T> {
     const previousTail = this.tail
     const newNode: Node<T> = new Node({
       data,
-      next: () => this.head,
-      previous: () => previousTail,
+      next: this.head ? () => this.head : null,
+      previous: previousTail ? () => previousTail : null,
     })
 
     if (this.tail) {
@@ -78,9 +80,12 @@ export class LinkedList<T> {
     this.tail = newNode
     if (!this.head) {
       this.head = newNode
+      newNode.next = () => this.head
     } else {
       this.head.previous = () => this.tail
     }
+
+    this.head.previous = () => this.tail
 
     return (this.size += 1)
   }
@@ -97,12 +102,12 @@ export class LinkedList<T> {
     previousIndex = 0,
     previousNode: Node<T> = this.head
   ): MaybeNode<T> {
-    // the head should be accessible via a negative index equal to the list size
-    if (targetIndex >= this.size || Math.abs(targetIndex) > this.size) return
-
     if (targetIndex === 0) {
       return callback ? callback(this.head) : this.head
     }
+
+    // the head should be accessible via a negative index equal to the list size
+    if (targetIndex >= this.size || Math.abs(targetIndex) > this.size) return
 
     let iteration, currentNode
 
@@ -136,45 +141,26 @@ export class LinkedList<T> {
     }
   }
 
-  // to do: refactor with newly added iteration method
-  insertAtIndex(data: T, index: NodeIndex): ListSize {
-    if (index === 0) {
-      return this.insertAtHead(data)
-    }
+  insertAtIndex(index: NodeIndex, data: T): ListSize {
+    if (index === 0) this.insertAtHead(data)
 
-    if (index >= this.size) {
-      return this.insertAtTail(data)
-    }
+    const shiftRight = index > -1
+    const nextNode = shiftRight
+      ? this.iterateThroughList(index)
+      : this.iterateThroughList(index).previous()
 
-    let currentNode = this.head
-    let previousNode
-    let nextNode
-    let count = 0
-    const insertNewNode = () => {
-      const newNode = new Node({
-        data,
-        next: () => previousNode.next,
-        previous: () => previousNode,
-      })
+    const previousNode = shiftRight ? nextNode.previous() : nextNode.next()
 
-      previousNode.next = () => newNode
-      newNode.next = () => nextNode
-      return (this.size += 1)
-    }
+    const newNode = new Node({
+      data,
+      next: () => nextNode,
+      previous: () => previousNode,
+    })
 
-    while (count < this.size) {
-      if (count === index - 1) {
-        previousNode = currentNode
-        nextNode = currentNode.next()
-      }
+    nextNode.previous = () => newNode
+    previousNode.next = () => newNode
 
-      if (count === index) {
-        return insertNewNode()
-      }
-
-      currentNode = currentNode.next()
-      count += 1
-    }
+    return (this.size += 1)
   }
 
   removeAtIndex(index: NodeIndex): ListSize {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,6 +1,7 @@
 import {LinkedList, Node} from '../index'
 import {describe, it} from 'mocha'
 import {assert} from 'chai'
+import {spy} from 'sinon'
 
 describe('LinkedList', () => {
   describe('constructor', () => {
@@ -216,6 +217,118 @@ describe('LinkedList', () => {
           assert.equal(newList.tail.next(), newList.head)
           assert.equal(newList.head.previous(), newList.tail)
         })
+      })
+    })
+  })
+
+  describe('iterateThroughList', () => {
+    describe('with a target index that is out of bounds', () => {
+      const newList: LinkedList<number> = new LinkedList({
+        head: undefined,
+      })
+
+      newList.insertAtHead(1)
+
+      it('returns undefined', () => {
+        assert.isUndefined(newList.iterateThroughList(2))
+      })
+    })
+
+    describe('with no callback argument recieved', () => {
+      const newList: LinkedList<number> = new LinkedList({
+        head: undefined,
+      })
+
+      newList.insertAtHead(1)
+      newList.insertAtTail(2)
+      newList.insertAtTail(3)
+
+      describe('with a target node index of 0', () => {
+        it('returns the head', () => {
+          assert.equal(newList.iterateThroughList(0), newList.head)
+        })
+      })
+
+      describe('with a positive integer for the target node index', () => {
+        it('returns the correct node', () => {
+          assert.equal(newList.iterateThroughList(1), newList.head.next())
+          assert.equal(newList.iterateThroughList(2), newList.tail)
+        })
+      })
+
+      describe('with a negative integer for the target node index', () => {
+        it('returns the correct node', () => {
+          assert.equal(newList.iterateThroughList(-1), newList.tail)
+          assert.equal(newList.iterateThroughList(-2), newList.tail.previous())
+          assert.equal(newList.iterateThroughList(-3), newList.head)
+        })
+      })
+    })
+
+    describe('with a callback argument', () => {
+      const newList: LinkedList<string | number> = new LinkedList({
+        head: undefined,
+      })
+
+      newList.insertAtHead(1)
+      newList.insertAtTail(2)
+      newList.insertAtTail(3)
+
+      const nodeIdentity = (node: Node<number>) => node
+      let identitySpy
+      // each test in this block should have a fresh spy
+      beforeEach(() => {
+        identitySpy = spy(nodeIdentity)
+      })
+
+      // curry the method under test for readability
+      const identifyOfNodeAtIndex = (index: number) =>
+        newList.iterateThroughList(index, identitySpy)
+
+      describe('with a target node index of 0', () => {
+        it('calls the callback with the target node', () => {
+          identifyOfNodeAtIndex(0)
+          assert(identitySpy.calledOnceWith(newList.head))
+        })
+      })
+
+      describe('with a positive integer for the target node index', () => {
+        it('calls the callback with the correct node', () => {
+          identifyOfNodeAtIndex(1)
+          assert(identitySpy.calledWith(newList.tail.previous()))
+
+          identifyOfNodeAtIndex(2)
+          assert(identitySpy.calledWith(newList.tail))
+        })
+      })
+
+      describe('with a negative integer for the target node index', () => {
+        it('calls the callback with the correct node', () => {
+          identifyOfNodeAtIndex(-1)
+          assert(identitySpy.calledWith(newList.tail))
+
+          identifyOfNodeAtIndex(-2)
+          assert(identitySpy.calledWith(newList.tail.previous()))
+
+          identifyOfNodeAtIndex(-3)
+          assert(identitySpy.calledWith(newList.head))
+        })
+      })
+    })
+  })
+
+  describe('insertAtIndex', () => {
+    describe('edge cases', () => {
+      it('calls insertAtHead when inserting at index === 0', () => {
+        const newList: LinkedList<number> = new LinkedList({
+          head: undefined,
+        })
+
+        spy(newList, 'insertAtHead')
+        spy(newList, 'insertAtTail')
+
+        newList.insertAtIndex(1, 0)
+        newList.insertAtIndex(2, 1)
       })
     })
   })

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -45,6 +45,11 @@ describe('LinkedList', () => {
         it('has a tail node that is the head node', () => {
           assert.equal(newList.head, newList.tail)
         })
+
+        it('links the head node to itself', () => {
+          assert.equal(newList.head.next(), newList.head)
+          assert.equal(newList.head.previous(), newList.head)
+        })
       })
     })
 
@@ -144,6 +149,11 @@ describe('LinkedList', () => {
 
         it('has a head node that is the tail node', () => {
           assert.equal(newList.head, newList.tail)
+        })
+
+        it('links the tail node to itself', () => {
+          assert.equal(newList.tail.previous(), newList.tail)
+          assert.equal(newList.tail.next(), newList.tail)
         })
       })
     })
@@ -319,16 +329,35 @@ describe('LinkedList', () => {
 
   describe('insertAtIndex', () => {
     describe('edge cases', () => {
+      const newList: LinkedList<number> = new LinkedList({
+        head: undefined,
+      })
+
+      const insertAtHeadSpy = spy(newList, 'insertAtHead')
+
       it('calls insertAtHead when inserting at index === 0', () => {
-        const newList: LinkedList<number> = new LinkedList({
-          head: undefined,
-        })
+        newList.insertAtIndex(0, 1)
+        assert(insertAtHeadSpy.calledWith(1))
+      })
+    })
 
-        spy(newList, 'insertAtHead')
-        spy(newList, 'insertAtTail')
+    describe('with a positive integer < this.size as the target index', () => {
+      const newList: LinkedList<number> = new LinkedList({
+        head: undefined,
+      })
 
-        newList.insertAtIndex(1, 0)
-        newList.insertAtIndex(2, 1)
+      newList.insertAtHead(1)
+      newList.insertAtTail(3)
+      newList.insertAtIndex(1, 2)
+      it('inserts a new node at the correct index', () => {
+        assert.equal(newList.size, 3)
+        assert.equal(newList.head.next().data, 2)
+      })
+
+      it('properly links the new node', () => {
+        assert.equal(newList.head.next(), newList.tail.previous())
+        assert.equal(newList.head.next().next(), newList.tail)
+        assert.equal(newList.tail.previous().previous(), newList.head)
       })
     })
   })


### PR DESCRIPTION
## What?

This PR includes:

a refactor of the method `insertAtIndex`
improvements to the method `iterateThroughList`
tests for both methods

## How?

the method `insertAtIndex` was rewritten to use existing iteration logic and handle edge cases

## Why?

the method insertAtIndex allows users to insert a new node without having to recreate an entire list
reusing the iteration logic prevents duplication of knowledge

## Testing?

Tests for both `insertAtIndex` and `iterateThroughList` are included in `test/index.spec.ts`