### PR TITLE
Merge branch Feature/removeAtIndex

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -142,14 +142,20 @@ export class LinkedList<T> {
   }
 
   insertAtIndex(index: NodeIndex, data: T): ListSize {
-    if (index === 0) this.insertAtHead(data)
+    if (index === 0 || index === this.size * -1) {
+      return this.insertAtHead(data)
+    }
 
-    const shiftRight = index > -1
-    const nextNode = shiftRight
-      ? this.iterateThroughList(index)
-      : this.iterateThroughList(index).previous()
+    if (index === this.size) {
+      return this.insertAtTail(data)
+    }
 
-    const previousNode = shiftRight ? nextNode.previous() : nextNode.next()
+    if (index > this.size || index <= (this.size + 1) * -1) {
+      return this.size
+    }
+
+    const nextNode = this.iterateThroughList(index)
+    const previousNode = nextNode.previous()
 
     const newNode = new Node({
       data,
@@ -164,6 +170,34 @@ export class LinkedList<T> {
   }
 
   removeAtIndex(index: NodeIndex): ListSize {
-    return this.size
+    if (this.size === 0 || index > this.size || index <= (this.size + 1) * -1) {
+      return this.size
+    }
+
+    if (this.size === 1) {
+      return this.emptyList()
+    }
+
+    const targetNode = this.iterateThroughList(index)
+
+    if (targetNode === this.head) {
+      this.head = this.head.next()
+    }
+
+    if (targetNode === this.tail) {
+      this.tail = this.tail.previous()
+    }
+
+    const nextNode = targetNode.next()
+    const previousNode = targetNode.previous()
+    previousNode.next = () => nextNode
+    nextNode.previous = () => previousNode
+    return (this.size -= 1)
+  }
+
+  emptyList(): ListSize {
+    this.head = null
+    this.tail = null
+    return (this.size = 0)
   }
 }

--- a/index.ts
+++ b/index.ts
@@ -96,7 +96,7 @@ export class LinkedList<T> {
   // this method will return the application of the callback to the node, if the user does
   // not supply a callback, this method will instead return the targeted node. This method is
   // unique in that if the targeted index is out of bounds, it will return undefined
-  iterateThroughList(
+  findNodeAtIndex(
     targetIndex: number,
     callback?: NodeFunction<T>,
     previousIndex = 0,
@@ -123,14 +123,14 @@ export class LinkedList<T> {
 
     switch (iteration) {
       case 'increment':
-        return this.iterateThroughList(
+        return this.findNodeAtIndex(
           targetIndex,
           callback,
           previousIndex + 1,
           previousNode.next()
         )
       case 'decrement':
-        return this.iterateThroughList(
+        return this.findNodeAtIndex(
           targetIndex,
           callback,
           previousIndex - 1,
@@ -154,7 +154,7 @@ export class LinkedList<T> {
       return this.size
     }
 
-    const nextNode = this.iterateThroughList(index)
+    const nextNode = this.findNodeAtIndex(index)
     const previousNode = nextNode.previous()
 
     const newNode = new Node({
@@ -178,7 +178,7 @@ export class LinkedList<T> {
       return this.emptyList()
     }
 
-    const targetNode = this.iterateThroughList(index)
+    const targetNode = this.findNodeAtIndex(index)
 
     if (targetNode === this.head) {
       this.head = this.head.next()

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -213,13 +213,13 @@ describe('LinkedList', () => {
     })
   })
 
-  describe('iterateThroughList', () => {
+  describe('findNodeAtIndex', () => {
     describe('with a target index that is out of bounds', () => {
       const newList = listFactory()
       newList.insertAtHead(1)
 
       it('returns undefined', () => {
-        assert.isUndefined(newList.iterateThroughList(2))
+        assert.isUndefined(newList.findNodeAtIndex(2))
       })
     })
 
@@ -231,22 +231,22 @@ describe('LinkedList', () => {
 
       describe('with a target node index of 0', () => {
         it('returns the head', () => {
-          assert.equal(newList.iterateThroughList(0), newList.head)
+          assert.equal(newList.findNodeAtIndex(0), newList.head)
         })
       })
 
       describe('with a positive integer for the target node index', () => {
         it('returns the correct node', () => {
-          assert.equal(newList.iterateThroughList(1), newList.head.next())
-          assert.equal(newList.iterateThroughList(2), newList.tail)
+          assert.equal(newList.findNodeAtIndex(1), newList.head.next())
+          assert.equal(newList.findNodeAtIndex(2), newList.tail)
         })
       })
 
       describe('with a negative integer for the target node index', () => {
         it('returns the correct node', () => {
-          assert.equal(newList.iterateThroughList(-1), newList.tail)
-          assert.equal(newList.iterateThroughList(-2), newList.tail.previous())
-          assert.equal(newList.iterateThroughList(-3), newList.head)
+          assert.equal(newList.findNodeAtIndex(-1), newList.tail)
+          assert.equal(newList.findNodeAtIndex(-2), newList.tail.previous())
+          assert.equal(newList.findNodeAtIndex(-3), newList.head)
         })
       })
     })
@@ -266,7 +266,7 @@ describe('LinkedList', () => {
 
       // curry the method under test for readability
       const identifyOfNodeAtIndex = (index: number) =>
-        newList.iterateThroughList(index, identitySpy)
+        newList.findNodeAtIndex(index, identitySpy)
 
       describe('with a target node index of 0', () => {
         it('calls the callback with the target node', () => {
@@ -433,7 +433,7 @@ describe('LinkedList', () => {
       newList.removeAtIndex(1)
 
       it('removes the target node', () => {
-        assert.equal(newList.iterateThroughList(1).data, 3)
+        assert.equal(newList.findNodeAtIndex(1).data, 3)
       })
 
       it('links the surrounding nodes', () => {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -3,12 +3,12 @@ import {describe, it} from 'mocha'
 import {assert} from 'chai'
 import {spy} from 'sinon'
 
+const listFactory = () => new LinkedList({head: undefined})
+
 describe('LinkedList', () => {
   describe('constructor', () => {
     describe('when not passed any nodes', () => {
-      const newList: LinkedList<Node<undefined>> = new LinkedList({
-        head: undefined,
-      })
+      const newList = listFactory()
 
       it('creates an empty list with size 0', () => {
         assert.equal(newList.size, 0, 'empty list does not have size 0')
@@ -23,10 +23,7 @@ describe('LinkedList', () => {
 
   describe('insertAtHead', () => {
     describe('with no previous nodes', () => {
-      const newList: LinkedList<number> = new LinkedList({
-        head: undefined,
-      })
-
+      const newList = listFactory()
       newList.insertAtHead(1)
 
       describe('adds an initial node', () => {
@@ -54,10 +51,7 @@ describe('LinkedList', () => {
     })
 
     describe('with a previous node', () => {
-      const newList: LinkedList<number> = new LinkedList({
-        head: undefined,
-      })
-
+      const newList = listFactory()
       newList.insertAtHead(1)
       newList.insertAtHead(2)
 
@@ -88,10 +82,7 @@ describe('LinkedList', () => {
     })
 
     describe('with two previous nodes', () => {
-      const newList: LinkedList<number> = new LinkedList({
-        head: undefined,
-      })
-
+      const newList = listFactory()
       newList.insertAtHead(1)
       newList.insertAtHead(2)
       newList.insertAtHead(3)
@@ -128,10 +119,7 @@ describe('LinkedList', () => {
 
   describe('insertAtTail', () => {
     describe('with no previous nodes', () => {
-      const newList: LinkedList<number> = new LinkedList({
-        head: undefined,
-      })
-
+      const newList = listFactory()
       newList.insertAtTail(1)
 
       describe('adds an initial node', () => {
@@ -159,10 +147,7 @@ describe('LinkedList', () => {
     })
 
     describe('with a previous node', () => {
-      const newList: LinkedList<number> = new LinkedList({
-        head: undefined,
-      })
-
+      const newList = listFactory()
       newList.insertAtTail(1)
       newList.insertAtTail(2)
 
@@ -193,10 +178,7 @@ describe('LinkedList', () => {
     })
 
     describe('with two previous nodes', () => {
-      const newList: LinkedList<number> = new LinkedList({
-        head: undefined,
-      })
-
+      const newList = listFactory()
       newList.insertAtTail(1)
       newList.insertAtTail(2)
       newList.insertAtTail(3)
@@ -233,10 +215,7 @@ describe('LinkedList', () => {
 
   describe('iterateThroughList', () => {
     describe('with a target index that is out of bounds', () => {
-      const newList: LinkedList<number> = new LinkedList({
-        head: undefined,
-      })
-
+      const newList = listFactory()
       newList.insertAtHead(1)
 
       it('returns undefined', () => {
@@ -245,10 +224,7 @@ describe('LinkedList', () => {
     })
 
     describe('with no callback argument recieved', () => {
-      const newList: LinkedList<number> = new LinkedList({
-        head: undefined,
-      })
-
+      const newList = listFactory()
       newList.insertAtHead(1)
       newList.insertAtTail(2)
       newList.insertAtTail(3)
@@ -276,10 +252,7 @@ describe('LinkedList', () => {
     })
 
     describe('with a callback argument', () => {
-      const newList: LinkedList<string | number> = new LinkedList({
-        head: undefined,
-      })
-
+      const newList = listFactory()
       newList.insertAtHead(1)
       newList.insertAtTail(2)
       newList.insertAtTail(3)
@@ -328,27 +301,37 @@ describe('LinkedList', () => {
   })
 
   describe('insertAtIndex', () => {
-    describe('edge cases', () => {
-      const newList: LinkedList<number> = new LinkedList({
-        head: undefined,
-      })
-
+    describe('handling edge cases', () => {
+      const newList = listFactory()
       const insertAtHeadSpy = spy(newList, 'insertAtHead')
+      const insertAtTailSpy = spy(newList, 'insertAtTail')
 
-      it('calls insertAtHead when inserting at index === 0', () => {
+      it('calls insertAtHead with target index === 0', () => {
         newList.insertAtIndex(0, 1)
         assert(insertAtHeadSpy.calledWith(1))
       })
-    })
 
-    describe('with a positive integer < this.size as the target index', () => {
-      const newList: LinkedList<number> = new LinkedList({
-        head: undefined,
+      it('calls insertAtTail with target index === this.size', () => {
+        newList.insertAtIndex(newList.size, 2)
+        assert(insertAtTailSpy.calledWith(2))
       })
 
+      it('calls insertAtHead with target index === (this.size * -1)', () => {
+        newList.insertAtIndex(newList.size * -1, 3)
+        assert(insertAtHeadSpy.calledWith(3))
+      })
+
+      it('returns the current size with target index out of bounds', () => {
+        assert.equal(newList.size, 3)
+      })
+    })
+
+    describe('with target index of a positive integer < this.size', () => {
+      const newList = listFactory()
       newList.insertAtHead(1)
       newList.insertAtTail(3)
       newList.insertAtIndex(1, 2)
+
       it('inserts a new node at the correct index', () => {
         assert.equal(newList.size, 3)
         assert.equal(newList.head.next().data, 2)
@@ -359,6 +342,126 @@ describe('LinkedList', () => {
         assert.equal(newList.head.next().next(), newList.tail)
         assert.equal(newList.tail.previous().previous(), newList.head)
       })
+    })
+
+    describe('with a negative integer greater than (this.size * -1)', () => {
+      const newList = listFactory()
+      newList.insertAtHead(1)
+      newList.insertAtTail(3)
+      newList.insertAtIndex(-1, 2)
+
+      it('inserts a new node at the correct index', () => {
+        assert.equal(newList.size, 3)
+        assert.equal(newList.head.next().data, 2)
+      })
+
+      it('properly links the new node', () => {
+        assert.equal(newList.head.next(), newList.tail.previous())
+        assert.equal(newList.head.next().next(), newList.tail)
+        assert.equal(newList.tail.previous().previous(), newList.head)
+      })
+    })
+  })
+
+  describe('removeAtIndex', () => {
+    describe('handling edge cases', () => {
+      const newList = listFactory()
+
+      describe('with an empty list', () => {
+        it('returns the list size of 0', () => {
+          assert.equal(newList.removeAtIndex(0), 0)
+        })
+      })
+
+      describe('with a single node', () => {
+        newList.insertAtHead(1)
+        const emptyListSpy = spy(newList, 'emptyList')
+
+        it('calls emptyList', () => {
+          assert(emptyListSpy.called)
+        })
+      })
+    })
+
+    describe('targetting the head node', () => {
+      const newList = listFactory()
+      newList.insertAtHead(1)
+      newList.insertAtTail(2)
+      newList.insertAtTail(3)
+      newList.removeAtIndex(0)
+
+      it('correctly reassigns the head', () => {
+        assert.equal(newList.head.data, 2)
+      })
+
+      it('removes the target node', () => {
+        assert.equal(newList.tail.next(), newList.head)
+        assert.equal(newList.head.previous(), newList.tail)
+      })
+
+      it('updates the size', () => {
+        assert.equal(newList.size, 2)
+      })
+    })
+
+    describe('targetting the tail node', () => {
+      const newList = listFactory()
+      newList.insertAtHead(1)
+      newList.insertAtTail(2)
+      newList.insertAtTail(3)
+      newList.removeAtIndex(newList.size - 1)
+
+      it('correctly reassigns the tail', () => {
+        assert.equal(newList.tail.data, 2)
+      })
+
+      it('removes the target node', () => {
+        assert.equal(newList.tail.next(), newList.head)
+        assert.equal(newList.head.previous(), newList.tail)
+      })
+
+      it('updates the size', () => {
+        assert.equal(newList.size, 2)
+      })
+    })
+
+    describe('targetting a non tail or head node', () => {
+      const newList = listFactory()
+      newList.insertAtHead(1)
+      newList.insertAtTail(2)
+      newList.insertAtTail(3)
+      newList.removeAtIndex(1)
+
+      it('removes the target node', () => {
+        assert.equal(newList.iterateThroughList(1).data, 3)
+      })
+
+      it('links the surrounding nodes', () => {
+        assert.equal(newList.tail.next(), newList.head)
+        assert.equal(newList.head.previous(), newList.tail)
+      })
+
+      it('updates the size', () => {
+        assert.equal(newList.size, 2)
+      })
+    })
+  })
+
+  describe('emptyList', () => {
+    const newList = listFactory()
+    newList.insertAtHead(1)
+    newList.insertAtTail(2)
+    newList.insertAtTail(3)
+    assert.equal(newList.size, 3)
+    newList.emptyList()
+
+    it('removes all nodes', () => {
+      assert.isNull(newList.head)
+      assert.isNull(newList.tail)
+    })
+
+    it('updates the list size', () => {
+      assert.equal(newList.size, 0)
     })
   })
 })


### PR DESCRIPTION
includes the following commits:

[Rename iterateThroughList to findNodeAtIndex](https://github.com/ErikWaters/DoublyLinkedList/commit/df5cf50f235cdd092a36a0a2d700401f1329d614)

[Add method removeAtIndex and emptyList](https://github.com/ErikWaters/DoublyLinkedList/commit/29e458583b85fb2accc8e55eb01eb7370a741083)