### PR TITLE
Make Lists Iterable, Add Array Like Methods

### DIFF
--- a/.README.md
+++ b/.README.md
@@ -2,21 +2,28 @@
 
 Doubly Linked List is a lightweight, dependency free linked list implementation in TypeScript.
 
+## Setting Up
+
+install with your package manager of choice and import
+
+`import {LinkedList} from 'doublylinkedlist'`
+
 ## About
 
 A list contains nodes that each have a data property, since the LinkedList class takes a generic type, the data property for each node will match a given type.
 
 ```
 const sweetNode = new Node<number>({data: 1})
+const sweetList = new LinkedList({head: sweetNode, size: 1})
+
+// is the same as
+
+const sweetNode = new LinkedList<number>()
+sweetNode.insertAtHead(1)
+
 ```
 
 Each node references a next and previous node via the `next` and `previous` properties (an arrow function that returns the relevant node).
-
-## Setting Up
-
-install with your package manager of choice and import
-
-`import {LinkedList} from 'doublylinkedlist'`
 
 ## Usage
 
@@ -26,7 +33,7 @@ new lists can be instantiated with or without existing nodes
 const niceList = new LinkedList()
 ```
 
-# Adding nodes
+# Adding Nodes
 
 Nodes can be added to lists at the head, tail, or any given index
 
@@ -38,7 +45,7 @@ niceList.insertAtTail(3) // list now has two nodes with data props of 1 and 3
 niceList.insertAtIndex(1, 2) // list now has three nodes with data props of 1, 2, and 3
 ```
 
-# using nodes
+# Using Nodes
 
 Nodes can be accessed individually by Index
 
@@ -68,7 +75,7 @@ niceList.iterateOverList(logNode) // data: 1, next: [Function], previous: [Funct
 
 Note: callbacks provided to these methods are expected to match the provided type NodeFunction
 
-# removing nodes
+# Removing Nodes
 
 Nodes are removed by a given index
 

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,5 +8,8 @@
     "eslint:recommended",
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended"
-  ]
+  ],
+  "rules" : {
+    "no-console" : "error"
+  }
 }

--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
-## Doubly Linked List
-
-Doubly Linked List is a lightweight, dependency free linked list implementation in TypeScript.
+# Doubly Linked List
 
 ## About
 
-A list contains nodes that each have a data property, since the LinkedList class takes a generic type, the data property for each node will match a given type.
+Doubly Linked List is a lightweight, dependency free "cyclic" linked list implementation in TypeScript.
 
-```
-const sweetNode = new Node<number>({data: 1})
-```
+Head and tail nodes automatically reference each other. This allows for iteration over a cyclic data structure without having to deal with "index math".
 
-Each node references a next and previous node via the `next` and `previous` properties (an arrow function that returns the relevant node).
+The LinkedList class provides various methods for maintaining the list itself and accessing nodes (see `Usage` below).
+
+LinkedLists are iterable and can be instantiated with any iterable.
 
 ## Setting Up
 
@@ -20,31 +18,43 @@ install with your package manager of choice and import
 
 ## Usage
 
-new lists can be instantiated with or without existing nodes
+A list contains nodes that have a data property, The LinkedList class takes a generic type that will match the data property for each node.
+
+Each node references a next and previous node via the `next` and `previous` properties.
+
+New lists can be instantiated with or without data. Thee following approaches are extensionally equivalent.
 
 ```
+// instantiating an empty list first
 const niceList = new LinkedList()
+niceList.addLast(1)
+niceList.addLast(2)
+
+// instantiating a list with data from an iterable
+const equallyNiceList = new LinkedList([1, 2])
+const anotherEquallyNiceList = new LinkedList(equallyNiceList)
 ```
 
-# Adding nodes
+### Adding Nodes
 
-Nodes can be added to lists at the head, tail, or any given index
+Nodes can be added to lists at the head, tail, or any given index. New Nodes are created automatically by the insertion method with no requirement to manually instantiate a new node.
 
 ```
-// new Nodes are created automatically and will take the data as an argument
-// there is no need to manually create a new node
-niceList.insertAtHead(1) // list now has one node with data prop of 1
-niceList.insertAtTail(3) // list now has two nodes with data props of 1 and 3
-niceList.insertAtIndex(1, 2) // list now has three nodes with data props of 1, 2, and 3
+niceList.addFirst(1)
+niceList.size // 1
+niceList.addLast(3)
+niceList.size // 2
+niceList.insert(1, 2)
+niceList.size // 3
 ```
 
-# using nodes
+### Using Nodes
 
 Nodes can be accessed individually by Index
 
 ```
-// probably don't do this if the node's index will change
-const niceListHead = niceList.findNodeAtIndex(0)
+// maybe don't do this if the node's index will change
+const niceListHead = niceList.at(0)
 ```
 
 this method can also take a callback for side effects
@@ -55,29 +65,31 @@ const logNode = node => {
   return node
 }
 
-niceList.findAtIndex(0, logNode) // data: 1, next: [Node], previous: [Node]
+niceList.at(0, logNode) // data: 1, next: [Node], previous: [Node]
 ```
 
-a list can also be iterated over to execute side effects
+lists can also be iterated over to execute side effects (similar to `Array.forEach`)
 
 ```
-niceList.iterateOverList(logNode) // data: 1, next: [Node], previous: [Node]
+niceList.forEach(logNode) // data: 1, next: [Node], previous: [Node]
 // data: 2, next: [Node], previous: [Node]
 // data: 3, next: [Node], previous: [Node]
 ```
 
-# removing nodes
+### Removing Nodes
 
-Nodes are removed by a given index
-
-```
-niceList.removeAtIndex(1) // list now has 2 nodes with data props of 1 and 3
-```
-
-or all at once
+Specific nodes are removed by a given index
 
 ```
-niceList.emptyList() // list is empty
+niceList.remove(1)
+niceList.size // 2
 ```
 
-Note: When Nodes are removed, they are unlinked from the surrounding nodes automatically
+Additionally, all nodes can be removed at once
+
+```
+niceList.clear()
+niceList.size // 3
+```
+
+Note: When Nodes are removed, they are unlinked from the surrounding nodes

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
 export interface Node<T> {
   data: T
-  next?: () => Node<T>
-  previous?: () => Node<T>
+  next: ReturnsNode<T>
+  previous: ReturnsNode<T>
 }
 
 export interface NodeConstructorArgs<T> {
@@ -10,31 +10,21 @@ export interface NodeConstructorArgs<T> {
   previous?: () => Node<T>
 }
 
+export type ReturnsNode<T> = () => Node<T>
+
 export class Node<T> {
   constructor({data, next, previous}: NodeConstructorArgs<T>) {
     this.data = data
-    this.next = next
-    this.previous = previous
+    this.next = next ? next : () => this
+    this.previous = previous ? previous : () => this
   }
 
   // this method is called on a Node when it is removed from a list in order to remove
   // circular references so that unneeded nodes may be garbage collected
   unlink(): void {
-    this.next = null
-    this.previous = null
+    this.next = () => this
+    this.previous = () => this
   }
-}
-
-export interface LinkedList<T> {
-  head: Node<T>
-  tail: Node<T>
-  size: number
-}
-
-export interface LinkedListConstructorArgs<T> {
-  head: Node<T>
-  tail?: Node<T>
-  size?: number
 }
 
 export type NodeFunction<T> = (node: Node<T>) => Node<T>
@@ -42,197 +32,303 @@ export type NodeIndex = number
 export type ListSize = number
 export type MaybeNode<T> = Node<T> | undefined
 
-// Keeping track of both a head and tail for a cyclical doubly linked list may seem redundant
-// since the tail is just the current head's previous node however; when adding new nodes at
-// the head we don't need to iterate through the entire list to get the new head's previous
-export class LinkedList<T> {
-  constructor({head, tail, size}: LinkedListConstructorArgs<T>) {
-    this.head = head
-    this.tail = tail
-    this.size = size ? size : 0
+export type IterationCallback<T> = (
+  currentNode: Node<T>,
+  currentIndex: NodeIndex,
+  list: LinkedList<T>
+) => void
+
+export type IterationPredicate<T> = (
+  currentNode: Node<T>,
+  currentIndex: NodeIndex,
+  list: LinkedList<T>
+) => boolean
+
+export interface EmptyList {
+  size: 0
+  head: undefined
+  tail: undefined
+}
+
+export interface ListWithData<T> {
+  size: 0
+  head: Node<T>
+  tail: Node<T>
+}
+
+export interface LinkedList<T> {
+  size: number
+  head?: Node<T>
+  tail?: Node<T>
+}
+
+export class LinkedList<T> implements Iterable<T> {
+  constructor(iterable?: Iterable<T>) {
+    this.size = 0
+
+    if (iterable) {
+      for (const item of iterable) {
+        this.addLast(item)
+      }
+    }
   }
 
-  insertAtHead(data: T): ListSize {
-    const previousHead = this.head
-    const newNode: Node<T> = new Node({
-      data,
-      next: previousHead ? () => previousHead : null,
-      previous: this.tail ? () => this.tail : null,
-    })
-
-    if (this.head) {
-      this.head.previous = () => newNode
+  [Symbol.iterator](): IterableIterator<T> {
+    const iterableIterator = {
+      values: this.toArray(),
+      current: 0,
+      [Symbol.iterator]: this[Symbol.iterator],
+      next: function (): IteratorResult<T> {
+        if (this.current < this.values.length) {
+          return {value: this.values[this.current++], done: false}
+        }
+        return {value: undefined, done: true}
+      },
     }
 
-    this.head = newNode
-
-    if (!this.tail) {
-      this.tail = newNode
-      newNode.previous = () => newNode
-    }
-
-    this.tail.next = () => this.head
-
-    return (this.size += 1)
+    return iterableIterator
   }
 
-  insertAtTail(data: T): ListSize {
-    const previousTail = this.tail
-    const newNode: Node<T> = new Node({
-      data,
-      next: this.head ? () => this.head : null,
-      previous: previousTail ? () => previousTail : null,
-    })
-
-    if (this.tail) {
-      this.tail.next = () => newNode
-    }
-
-    this.tail = newNode
-    if (!this.head) {
-      this.head = newNode
-      newNode.next = () => this.head
-    } else {
-      this.head.previous = () => this.tail
-    }
-
-    this.head.previous = () => this.tail
-
-    return (this.size += 1)
+  isListWithData(
+    list: LinkedList<T> | EmptyList | ListWithData<T>
+  ): list is ListWithData<T> {
+    return (list as ListWithData<T>).size >= 1 && !!list.tail && !!list.head
   }
 
-  // the intention behind this method is to provide baked in iteration in both directions
-  // (forward and backward) with a mechanism to execute a user provided side effect
-  // (for extensibility) in the form of a callback. When the targeted node is found
-  // this method will return the application of the callback to the node, if the user does
-  // not supply a callback, this method will instead return the targeted node. This method is
-  // unique in that if the targeted index is out of bounds, it will return undefined
-  findNodeAtIndex(
+  addFirst(data: T): ListSize {
+    return this.insert(0, data)
+  }
+
+  addLast(data: T): ListSize {
+    return this.insert(this.size, data)
+  }
+
+  // LinkedList.at iterates through the list to find a node specified by index:
+  // with a positive targeIndex - at iterates through the nodes "from left to right"
+  // as a zero based index: an index of 0 references the head, an index of this.size - 1
+  // references the tail
+  // with a negative targetIndex - at iterates through the list "from right to left"
+  // as a one based index: an index of -1 references the tail, an index of this.size * -1
+  // references the head
+  // if a function is provided as an argument to the second parameter: callback, at returns
+  // the application of that function to the target node, otherwise at returns the node itself
+  // if the targeted index is out of bounds, at returns undefined
+  at(
     targetIndex: number,
-    callback?: NodeFunction<T>,
-    previousIndex = 0,
-    previousNode: Node<T> = this.head
+    callback: NodeFunction<T> = node => node
   ): MaybeNode<T> {
-    if (targetIndex === 0) {
-      return callback ? callback(this.head) : this.head
+    // the head should be accessible via a negative index with magnitude equal to the list size: this.size * -1
+    if (
+      !this.isListWithData(this) ||
+      targetIndex >= this.size ||
+      Math.abs(targetIndex) > this.size
+    )
+      return
+
+    if (targetIndex === 0 || targetIndex === this.size * -1)
+      return callback(this.head)
+
+    if (this.tail && (targetIndex === this.size - 1 || targetIndex === -1))
+      return callback(this.tail)
+
+    const iterate = (
+      targetIndex: number,
+      callback: NodeFunction<T>,
+      previousIndex: NodeIndex,
+      previousNode: Node<T> | undefined
+    ): MaybeNode<T> => {
+      let iteration,
+        currentNode = previousNode
+
+      if (targetIndex > 0 && targetIndex > previousIndex + 1) {
+        iteration = 'increment'
+      } else if (targetIndex < 0 && targetIndex < previousIndex - 1) {
+        iteration = 'decrement'
+      } else {
+        iteration = 'done'
+        currentNode =
+          targetIndex > 0 ? previousNode?.next() : previousNode?.previous()
+      }
+
+      switch (iteration) {
+        case 'increment':
+          return iterate(
+            targetIndex,
+            callback,
+            previousIndex + 1,
+            previousNode?.next()
+          )
+        case 'decrement':
+          return iterate(
+            targetIndex,
+            callback,
+            previousIndex - 1,
+            previousNode?.previous()
+          )
+        default:
+          return currentNode ? callback(currentNode) : undefined
+      }
     }
 
-    // the head should be accessible via a negative index equal to the list size
-    if (targetIndex >= this.size || Math.abs(targetIndex) > this.size) return
-
-    let iteration, currentNode
-
-    if (targetIndex > 0 && targetIndex > previousIndex + 1) {
-      iteration = 'increment'
-    } else if (targetIndex < 0 && targetIndex < previousIndex - 1) {
-      iteration = 'decrement'
-    } else {
-      iteration = 'done'
-      currentNode =
-        targetIndex > 0 ? previousNode.next() : previousNode.previous()
-    }
-
-    switch (iteration) {
-      case 'increment':
-        return this.findNodeAtIndex(
-          targetIndex,
-          callback,
-          previousIndex + 1,
-          previousNode.next()
-        )
-      case 'decrement':
-        return this.findNodeAtIndex(
-          targetIndex,
-          callback,
-          previousIndex - 1,
-          previousNode.previous()
-        )
-      default:
-        return callback ? callback(currentNode) : currentNode
-    }
+    return iterate(targetIndex, callback, 0, this.head)
   }
 
-  insertAtIndex(index: NodeIndex, data: T): ListSize {
-    if (index === 0 || index === this.size * -1) {
-      return this.insertAtHead(data)
-    }
-
-    if (index === this.size) {
-      return this.insertAtTail(data)
-    }
-
+  insert(index: NodeIndex, data: T): ListSize {
     if (index > this.size || index <= (this.size + 1) * -1) {
       return this.size
     }
 
-    const nextNode = this.findNodeAtIndex(index)
+    const newNode: Node<T> = new Node({data})
+    let nextNode = newNode.next()
+
+    if (this.isListWithData(this) && index === this.size) {
+      nextNode = this.head
+    } else {
+      const nodeAtIndex = this.at(index)
+      if (nodeAtIndex) nextNode = nodeAtIndex
+    }
+
     const previousNode = nextNode.previous()
 
-    const newNode = new Node({
-      data,
-      next: () => nextNode,
-      previous: () => previousNode,
-    })
+    if (this.isListWithData(this)) {
+      newNode.next = () => nextNode
+      newNode.previous = () => previousNode
+    }
 
     nextNode.previous = () => newNode
     previousNode.next = () => newNode
 
+    if (index === 0 || index === this.size * -1) {
+      this.head = newNode
+    }
+
+    if (index === this.size) {
+      this.tail = newNode
+    }
+
     return (this.size += 1)
   }
 
-  removeAtIndex(index: NodeIndex): ListSize {
-    if (this.size === 0 || index > this.size || index <= (this.size + 1) * -1) {
-      return this.size
-    }
-
+  remove(index: NodeIndex): ListSize {
     if (this.size === 1) {
-      return this.emptyList()
+      return this.clear()
     }
 
-    const targetNode = this.findNodeAtIndex(index)
+    const nodeAtIndex: MaybeNode<T> = this.at(index)
 
-    if (targetNode === this.head) {
+    if (!nodeAtIndex) return this.size
+
+    if (nodeAtIndex === this.head) {
       this.head = this.head.next()
     }
 
-    if (targetNode === this.tail) {
+    if (nodeAtIndex === this.tail) {
       this.tail = this.tail.previous()
     }
 
-    const nextNode = targetNode.next()
-    const previousNode = targetNode.previous()
+    const nextNode = nodeAtIndex.next()
+    const previousNode = nodeAtIndex.previous()
     previousNode.next = () => nextNode
     nextNode.previous = () => previousNode
-    targetNode.unlink()
+    nodeAtIndex.unlink()
     return (this.size -= 1)
   }
 
-  iterateOverList(
-    callback: NodeFunction<T>,
-    currentNode: Node<T> = this.head,
-    currentIndex: NodeIndex = 0,
-    finalIndex: NodeIndex = this.size - 1
-  ): void {
-    const nextNode = currentNode.next()
+  clear(): ListSize {
+    const unlinkNode = (node: Node<T>) => node.unlink()
+    this.forEach(unlinkNode)
+    this.head = undefined
+    this.tail = undefined
+    return (this.size = 0)
+  }
 
-    if (currentIndex <= finalIndex) {
-      callback(currentNode)
-    }
+  forEach(callback: IterationCallback<T>): void {
+    if (this.isListWithData(this)) {
+      const iterate = (
+        callback: IterationCallback<T>,
+        currentNode: Node<T>,
+        currentIndex: NodeIndex,
+        list: this = this
+      ): void => {
+        const nextNode = currentNode?.next()
 
-    if (currentIndex < finalIndex) {
-      this.iterateOverList(callback, nextNode, currentIndex + 1, finalIndex)
+        if (!currentNode) return
+
+        if (currentIndex <= this.size - 1) {
+          callback(currentNode, currentIndex, list)
+        }
+
+        if (currentIndex < this.size - 1) {
+          iterate(callback, nextNode, currentIndex + 1, list)
+        }
+      }
+
+      iterate(callback, this.head, 0, this)
     }
   }
 
-  emptyList(): ListSize {
-    const unlinkNode = node => {
-      this.size -= 1
-      node.unlink()
+  filter(callback: IterationPredicate<T>): LinkedList<T | unknown> {
+    const filteredList = new LinkedList()
+
+    if (this.isListWithData(this)) {
+      const iterate = (
+        callback: IterationPredicate<T>,
+        currentNode: Node<T>,
+        currentIndex: NodeIndex,
+        list: this = this
+      ): void => {
+        const nextNode = currentNode?.next()
+
+        if (!currentNode) return
+
+        if (currentIndex <= this.size - 1) {
+          if (callback(currentNode, currentIndex, list)) {
+            filteredList.addLast(currentNode.data)
+          }
+        }
+
+        if (currentIndex < this.size - 1) {
+          iterate(callback, nextNode, currentIndex + 1, list)
+        }
+      }
+
+      iterate(callback, this.head, 0, this)
+    }
+    return filteredList
+  }
+
+  toArray(): Array<T> {
+    const arr = [] as Array<T>
+
+    this.forEach(node => arr.push(node.data))
+
+    return arr
+  }
+
+  includes(datum: T): boolean {
+    let includesDatum = false
+
+    this.forEach(node => {
+      if (node.data === datum) {
+        includesDatum = true
+      }
+    })
+
+    return includesDatum
+  }
+
+  slice(
+    startIndex: NodeIndex,
+    endIndex: NodeIndex = this.size
+  ): LinkedList<T | unknown> {
+    // normalize in case of negative values
+    if (startIndex < 0) {
+      startIndex = this.size + startIndex
+    }
+    if (endIndex < 0) {
+      endIndex = this.size + endIndex
     }
 
-    this.iterateOverList(unlinkNode.bind(this))
-    this.head = null
-    this.tail = null
-    return this.size
+    return this.filter((cur, i) => i >= startIndex && i < endIndex)
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -209,6 +209,19 @@
       "integrity": "sha512-vyxR57nv8NfcU0GZu8EUXZLTbCMupIUwy95LJ6lllN+JRPG25CwMHoB1q5xKh8YKhQnHYRAn4yW2yuHbf/5xgg==",
       "dev": true
     },
+    "@types/sinon": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.9.tgz",
+      "integrity": "sha512-z/y8maYOQyYLyqaOB+dYQ6i0pxKLOsfwCmHmn4T7jS/SDHicIslr37oE3Dg8SCqKrKeBy6Lemu7do2yy+unLrw==",
+      "requires": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinonjs__fake-timers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
+      "integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg=="
+    },
     "@typescript-eslint/eslint-plugin": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
     "sinon": "^9.2.0",
     "ts-node": "^9.0.0",
     "typescript": "^4.1.0-beta"
+  },
+  "dependencies": {
+    "@types/sinon": "^9.0.9"
   }
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -3,401 +3,198 @@ import {describe, it} from 'mocha'
 import {assert} from 'chai'
 import {spy} from 'sinon'
 
-const listFactory = () => new LinkedList({head: undefined})
+const emptyListFactory = () => new LinkedList()
 
 describe('LinkedList', () => {
   describe('constructor', () => {
     describe('when not passed any nodes', () => {
-      const newList = listFactory()
+      const emptyList = emptyListFactory()
 
       it('creates an empty list with size 0', () => {
-        assert.equal(newList.size, 0, 'empty list does not have size 0')
+        assert.equal(emptyList.size, 0, 'empty list does not have size 0')
       })
 
       it('creates an empty list with no nodes', () => {
-        assert.isUndefined(newList.head, 'empty list has a head')
-        assert.isUndefined(newList.tail, 'empty list has a tail')
+        assert.isUndefined(emptyList.head, 'empty list has a head')
+        assert.isUndefined(emptyList.tail, 'empty list has a tail')
+      })
+    })
+
+    describe('when duplicating an existing list', () => {
+      const originalList = new LinkedList([1, 2, 3]) as LinkedList<number>
+      const duplicateList = new LinkedList(originalList)
+
+      it('creates a new list', () => {
+        assert.notDeepEqual(originalList, duplicateList)
+      })
+
+      it('creates a new list with the correct properties', () => {
+        assert.equal(originalList.size, duplicateList.size)
+        assert.equal(originalList.head?.data, duplicateList.head?.data)
+        assert.equal(originalList.tail?.data, duplicateList.tail?.data)
       })
     })
   })
 
-  describe('insertAtHead', () => {
-    describe('with no previous nodes', () => {
-      const newList = listFactory()
-      newList.insertAtHead(1)
+  describe('addFirst', () => {
+    const newList = emptyListFactory()
+    const insertSpy = spy(newList, 'insert')
+    newList.addFirst(1)
 
-      describe('adds an initial node', () => {
-        it('increments the size to 1', () => {
-          assert.equal(
-            newList.size,
-            1,
-            'new list with one node does not have size 1'
-          )
-        })
-
-        it('has a head node with the correct data', () => {
-          assert.equal(newList.head.data, 1)
-        })
-
-        it('has a tail node that is the head node', () => {
-          assert.equal(newList.head, newList.tail)
-        })
-
-        it('links the head node to itself', () => {
-          assert.equal(newList.head.next(), newList.head)
-          assert.equal(newList.head.previous(), newList.head)
-        })
-      })
-    })
-
-    describe('with a previous node', () => {
-      const newList = listFactory()
-      newList.insertAtHead(1)
-      newList.insertAtHead(2)
-
-      describe('adds a new node at the head of the list', () => {
-        it('increments the size to 2', () => {
-          assert.equal(
-            newList.size,
-            2,
-            'new list with one node does not have size 2'
-          )
-        })
-
-        it('replaces the previous head with the new node', () => {
-          assert.equal(newList.head.data, 2)
-        })
-
-        it('keeps the existing structure intact', () => {
-          assert.equal(newList.tail.data, 1)
-        })
-
-        it('links the tail to the new head', () => {
-          assert.equal(newList.tail.next(), newList.head)
-          assert.equal(newList.tail.previous(), newList.head)
-          assert.equal(newList.head.next(), newList.tail)
-          assert.equal(newList.head.previous(), newList.tail)
-        })
-      })
-    })
-
-    describe('with two previous nodes', () => {
-      const newList = listFactory()
-      newList.insertAtHead(1)
-      newList.insertAtHead(2)
-      newList.insertAtHead(3)
-
-      describe('adds a new node at the head of the list', () => {
-        it('increments the size to 3', () => {
-          assert.equal(
-            newList.size,
-            3,
-            'new list with one node does not have size 3'
-          )
-        })
-
-        it('replaces the previous head with the new node', () => {
-          assert.equal(newList.head.data, 3)
-        })
-
-        it('keeps the existing structure intact', () => {
-          assert.equal(newList.tail.data, 1)
-          assert.equal(newList.tail.previous().data, 2)
-        })
-
-        it('links the head to the second node', () => {
-          assert.equal(newList.head.next(), newList.tail.previous())
-        })
-
-        it('links the tail to the new head', () => {
-          assert.equal(newList.tail.next(), newList.head)
-          assert.equal(newList.head.previous(), newList.tail)
-        })
-      })
+    it('calls insert with the correct arguments', () => {
+      assert(insertSpy.calledWith(0, 1))
     })
   })
 
-  describe('insertAtTail', () => {
-    describe('with no previous nodes', () => {
-      const newList = listFactory()
-      newList.insertAtTail(1)
+  describe('addLast', () => {
+    const newList = emptyListFactory()
+    const insertSpy = spy(newList, 'insert')
+    newList.addLast(1)
 
-      describe('adds an initial node', () => {
-        it('increments the size to 1', () => {
-          assert.equal(
-            newList.size,
-            1,
-            'new list with one node does not have size 1'
-          )
-        })
-
-        it('has a tail node with the correct data', () => {
-          assert.equal(newList.tail.data, 1)
-        })
-
-        it('has a head node that is the tail node', () => {
-          assert.equal(newList.head, newList.tail)
-        })
-
-        it('links the tail node to itself', () => {
-          assert.equal(newList.tail.previous(), newList.tail)
-          assert.equal(newList.tail.next(), newList.tail)
-        })
-      })
-    })
-
-    describe('with a previous node', () => {
-      const newList = listFactory()
-      newList.insertAtTail(1)
-      newList.insertAtTail(2)
-
-      describe('adds a new node at the tail of the list', () => {
-        it('increments the size to 2', () => {
-          assert.equal(
-            newList.size,
-            2,
-            'new list with one node does not have size 2'
-          )
-        })
-
-        it('replaces the previous tail with the new node', () => {
-          assert.equal(newList.tail.data, 2)
-        })
-
-        it('keeps the existing structure intact', () => {
-          assert.equal(newList.head.data, 1)
-        })
-
-        it('links the head to the new tail', () => {
-          assert.equal(newList.tail.next(), newList.head)
-          assert.equal(newList.tail.previous(), newList.head)
-          assert.equal(newList.head.next(), newList.tail)
-          assert.equal(newList.head.previous(), newList.tail)
-        })
-      })
-    })
-
-    describe('with two previous nodes', () => {
-      const newList = listFactory()
-      newList.insertAtTail(1)
-      newList.insertAtTail(2)
-      newList.insertAtTail(3)
-
-      describe('adds a new node at the tail end of the list', () => {
-        it('increments the size to 3', () => {
-          assert.equal(
-            newList.size,
-            3,
-            'new list with one node does not have size 3'
-          )
-        })
-
-        it('replaces the previous tail with the new node', () => {
-          assert.equal(newList.tail.data, 3)
-        })
-
-        it('keeps the existing structure intact', () => {
-          assert.equal(newList.head.data, 1)
-          assert.equal(newList.head.next().data, 2)
-        })
-
-        it('links the tail to the second node', () => {
-          assert.equal(newList.tail.previous(), newList.head.next())
-        })
-
-        it('links the head to the new tail', () => {
-          assert.equal(newList.tail.next(), newList.head)
-          assert.equal(newList.head.previous(), newList.tail)
-        })
-      })
+    it('calls insert with the correct arguments', () => {
+      assert(insertSpy.calledWith(0, 1))
     })
   })
 
-  describe('findNodeAtIndex', () => {
+  describe('at', () => {
     describe('with a target index that is out of bounds', () => {
-      const newList = listFactory()
-      newList.insertAtHead(1)
+      const newList = new LinkedList([1])
 
       it('returns undefined', () => {
-        assert.isUndefined(newList.findNodeAtIndex(2))
+        assert.isUndefined(newList.at(2))
       })
     })
 
     describe('with no callback argument recieved', () => {
-      const newList = listFactory()
-      newList.insertAtHead(1)
-      newList.insertAtTail(2)
-      newList.insertAtTail(3)
+      const newList = new LinkedList([1, 2, 3])
 
       describe('with a target node index of 0', () => {
         it('returns the head', () => {
-          assert.equal(newList.findNodeAtIndex(0), newList.head)
+          assert.equal(newList.at(0), newList.head)
         })
       })
 
       describe('with a positive integer for the target node index', () => {
         it('returns the correct node', () => {
-          assert.equal(newList.findNodeAtIndex(1), newList.head.next())
-          assert.equal(newList.findNodeAtIndex(2), newList.tail)
+          assert.equal(newList.at(1), newList.head?.next())
+          assert.equal(newList.at(2), newList.tail)
         })
       })
 
       describe('with a negative integer for the target node index', () => {
         it('returns the correct node', () => {
-          assert.equal(newList.findNodeAtIndex(-1), newList.tail)
-          assert.equal(newList.findNodeAtIndex(-2), newList.tail.previous())
-          assert.equal(newList.findNodeAtIndex(-3), newList.head)
+          assert.equal(newList.at(-1), newList.tail)
+          assert.equal(newList.at(-2), newList.tail?.previous())
+          assert.equal(newList.at(-3), newList.head)
         })
       })
     })
 
     describe('with a callback argument', () => {
-      const newList = listFactory()
-      newList.insertAtHead(1)
-      newList.insertAtTail(2)
-      newList.insertAtTail(3)
+      const newList = new LinkedList([1, 2, 3]) as LinkedList<number>
 
-      const nodeIdentity = (node: Node<number>) => node
-      let identitySpy
-      // each test in this block should have a fresh spy
-      beforeEach(() => {
-        identitySpy = spy(nodeIdentity)
-      })
+      const identity = (any: Node<number>): Node<number> => any
 
       // curry the method under test for readability
-      const identifyOfNodeAtIndex = (index: number) =>
-        newList.findNodeAtIndex(index, identitySpy)
+      const identifyOfNodeAt = (index: number) => newList.at(index, identity)
 
       describe('with a target node index of 0', () => {
         it('calls the callback with the target node', () => {
-          identifyOfNodeAtIndex(0)
-          assert(identitySpy.calledOnceWith(newList.head))
+          assert.equal(identifyOfNodeAt(0)?.data, 1)
         })
       })
 
       describe('with a positive integer for the target node index', () => {
         it('calls the callback with the correct node', () => {
-          identifyOfNodeAtIndex(1)
-          assert(identitySpy.calledWith(newList.tail.previous()))
-
-          identifyOfNodeAtIndex(2)
-          assert(identitySpy.calledWith(newList.tail))
+          assert.equal(identifyOfNodeAt(1)?.data, 2)
+          assert.equal(identifyOfNodeAt(2)?.data, 3)
         })
       })
 
       describe('with a negative integer for the target node index', () => {
         it('calls the callback with the correct node', () => {
-          identifyOfNodeAtIndex(-1)
-          assert(identitySpy.calledWith(newList.tail))
-
-          identifyOfNodeAtIndex(-2)
-          assert(identitySpy.calledWith(newList.tail.previous()))
-
-          identifyOfNodeAtIndex(-3)
-          assert(identitySpy.calledWith(newList.head))
+          assert.equal(identifyOfNodeAt(-1)?.data, 3)
+          assert.equal(identifyOfNodeAt(-2)?.data, 2)
+          assert.equal(identifyOfNodeAt(-3)?.data, 1)
         })
       })
     })
   })
 
-  describe('insertAtIndex', () => {
+  describe('insert', () => {
     describe('handling edge cases', () => {
-      const newList = listFactory()
-      const insertAtHeadSpy = spy(newList, 'insertAtHead')
-      const insertAtTailSpy = spy(newList, 'insertAtTail')
-
-      it('calls insertAtHead with target index === 0', () => {
-        newList.insertAtIndex(0, 1)
-        assert(insertAtHeadSpy.calledWith(1))
-      })
-
-      it('calls insertAtTail with target index === this.size', () => {
-        newList.insertAtIndex(newList.size, 2)
-        assert(insertAtTailSpy.calledWith(2))
-      })
-
-      it('calls insertAtHead with target index === (this.size * -1)', () => {
-        newList.insertAtIndex(newList.size * -1, 3)
-        assert(insertAtHeadSpy.calledWith(3))
-      })
+      const newList = emptyListFactory()
 
       it('returns the current size with target index out of bounds', () => {
-        assert.equal(newList.size, 3)
+        assert.equal(newList.insert(1, 1), 0)
       })
     })
 
     describe('with target index of a positive integer < this.size', () => {
-      const newList = listFactory()
-      newList.insertAtHead(1)
-      newList.insertAtTail(3)
-      newList.insertAtIndex(1, 2)
+      const newList = new LinkedList([1, 3])
+      newList.insert(1, 2)
 
       it('inserts a new node at the correct index', () => {
         assert.equal(newList.size, 3)
-        assert.equal(newList.head.next().data, 2)
+        assert.equal(newList.head?.next().data, 2)
       })
 
       it('properly links the new node', () => {
-        assert.equal(newList.head.next(), newList.tail.previous())
-        assert.equal(newList.head.next().next(), newList.tail)
-        assert.equal(newList.tail.previous().previous(), newList.head)
+        assert.equal(newList.head?.next(), newList.tail?.previous())
+        assert.equal(newList.head?.next().next(), newList.tail)
+        assert.equal(newList.tail?.previous().previous(), newList.head)
       })
     })
 
     describe('with a negative integer greater than (this.size * -1)', () => {
-      const newList = listFactory()
-      newList.insertAtHead(1)
-      newList.insertAtTail(3)
-      newList.insertAtIndex(-1, 2)
+      const newList = new LinkedList([1, 3])
+      newList.insert(-1, 2)
 
       it('inserts a new node at the correct index', () => {
         assert.equal(newList.size, 3)
-        assert.equal(newList.head.next().data, 2)
+        assert.equal(newList.head?.next().data, 2)
       })
 
       it('properly links the new node', () => {
-        assert.equal(newList.head.next(), newList.tail.previous())
-        assert.equal(newList.head.next().next(), newList.tail)
-        assert.equal(newList.tail.previous().previous(), newList.head)
+        assert.equal(newList.head?.next(), newList.tail?.previous())
+        assert.equal(newList.head?.next().next(), newList.tail)
+        assert.equal(newList.tail?.previous().previous(), newList.head)
       })
     })
   })
 
-  describe('removeAtIndex', () => {
+  describe('remove', () => {
     describe('handling edge cases', () => {
-      const newList = listFactory()
+      const newList = emptyListFactory()
 
       describe('with an empty list', () => {
         it('returns the list size of 0', () => {
-          assert.equal(newList.removeAtIndex(0), 0)
+          assert.equal(newList.remove(0), 0)
         })
       })
 
       describe('with a single node', () => {
-        newList.insertAtHead(1)
-        const emptyListSpy = spy(newList, 'emptyList')
+        newList.addFirst(1)
+        const clearSpy = spy(newList, 'clear')
 
-        it('calls emptyList', () => {
-          assert(emptyListSpy.called)
+        it('calls clear', () => {
+          assert(clearSpy.called)
         })
       })
     })
 
     describe('targetting the head node', () => {
-      const newList = listFactory()
-      newList.insertAtHead(1)
-      newList.insertAtTail(2)
-      newList.insertAtTail(3)
-      const head = newList.findNodeAtIndex(0)
-      newList.removeAtIndex(0)
+      const newList = new LinkedList([1, 2, 3])
+      const head = newList.at(0)
+      newList.remove(0)
 
       it('correctly reassigns the head', () => {
-        assert.equal(newList.head.data, 2)
+        assert.equal(newList.head?.data, 2)
       })
 
       it('removes the target node', () => {
-        assert.equal(newList.tail.next(), newList.head)
-        assert.equal(newList.head.previous(), newList.tail)
+        assert.equal(newList.tail?.next(), newList.head)
+        assert.equal(newList.head?.previous(), newList.tail)
       })
 
       it('updates the size', () => {
@@ -405,26 +202,23 @@ describe('LinkedList', () => {
       })
 
       it('dereferences the surrounding nodes from the removed node', () => {
-        assert.isNull(head.next)
-        assert.isNull(head.previous)
+        assert.deepEqual(head?.next(), head)
+        assert.deepEqual(head?.previous(), head)
       })
     })
 
     describe('targetting the tail node', () => {
-      const newList = listFactory()
-      newList.insertAtHead(1)
-      newList.insertAtTail(2)
-      newList.insertAtTail(3)
-      const tail = newList.findNodeAtIndex(2)
-      newList.removeAtIndex(newList.size - 1)
+      const newList = new LinkedList([1, 2, 3])
+      const tail = newList.at(2)
+      newList.remove(newList.size - 1)
 
       it('correctly reassigns the tail', () => {
-        assert.equal(newList.tail.data, 2)
+        assert.equal(newList.tail?.data, 2)
       })
 
       it('removes the target node', () => {
-        assert.equal(newList.tail.next(), newList.head)
-        assert.equal(newList.head.previous(), newList.tail)
+        assert.equal(newList.tail?.next(), newList.head)
+        assert.equal(newList.head?.previous(), newList.tail)
       })
 
       it('updates the size', () => {
@@ -432,26 +226,23 @@ describe('LinkedList', () => {
       })
 
       it('dereferences the surrounding nodes from the removed node', () => {
-        assert.isNull(tail.next)
-        assert.isNull(tail.previous)
+        assert.deepEqual(tail?.next(), tail)
+        assert.deepEqual(tail?.previous(), tail)
       })
     })
 
     describe('targetting a non tail or head node', () => {
-      const newList = listFactory()
-      newList.insertAtHead(1)
-      newList.insertAtTail(2)
-      newList.insertAtTail(3)
-      const middle = newList.findNodeAtIndex(1)
-      newList.removeAtIndex(1)
+      const newList = new LinkedList([1, 2, 3])
+      const middle = newList.at(1)
+      newList.remove(1)
 
       it('removes the target node', () => {
-        assert.equal(newList.findNodeAtIndex(1).data, 3)
+        assert.equal(newList.at(1)?.data, 3)
       })
 
       it('links the surrounding nodes', () => {
-        assert.equal(newList.tail.next(), newList.head)
-        assert.equal(newList.head.previous(), newList.tail)
+        assert.equal(newList.tail?.next(), newList.head)
+        assert.equal(newList.head?.previous(), newList.tail)
       })
 
       it('updates the size', () => {
@@ -459,25 +250,22 @@ describe('LinkedList', () => {
       })
 
       it('dereferences the surrounding nodes from the removed node', () => {
-        assert.isNull(middle.next)
-        assert.isNull(middle.previous)
+        assert.deepEqual(middle?.next(), middle)
+        assert.deepEqual(middle?.previous(), middle)
       })
     })
   })
 
-  describe('iterateOverList', () => {
-    const newList = listFactory()
-    newList.insertAtHead(1)
-    newList.insertAtTail(2)
-    newList.insertAtTail(3)
-    const results = []
-    const pushDataFromNode = node => {
+  describe('forEach', () => {
+    const newList = new LinkedList([1, 2, 3])
+    const results = [] as number[]
+    const pushDataFromNode = (node: Node<number>) => {
       results.push(node.data)
       return node
     }
 
     const callbackSpy = spy(pushDataFromNode)
-    newList.iterateOverList(callbackSpy)
+    newList.forEach(callbackSpy)
 
     it('applies the callback to each node in the list', () => {
       assert(callbackSpy.calledThrice)
@@ -485,21 +273,113 @@ describe('LinkedList', () => {
     })
   })
 
-  describe('emptyList', () => {
-    const newList = listFactory()
-    newList.insertAtHead(1)
-    newList.insertAtTail(2)
-    newList.insertAtTail(3)
+  describe('clear', () => {
+    const newList = new LinkedList([1, 2, 3])
     assert.equal(newList.size, 3)
-    newList.emptyList()
+    newList.clear()
 
     it('removes all nodes', () => {
-      assert.isNull(newList.head)
-      assert.isNull(newList.tail)
+      assert.isUndefined(newList.head)
+      assert.isUndefined(newList.tail)
     })
 
     it('updates the list size', () => {
       assert.equal(newList.size, 0)
+    })
+  })
+
+  describe('toArray', () => {
+    const newList = emptyListFactory()
+    newList.addFirst(1)
+    newList.addLast(2)
+    const arrFromList = newList.toArray()
+
+    it('returns an array', () => {
+      assert.isArray(arrFromList)
+    })
+
+    it('returns an array with the correct properties', () => {
+      assert.equal(arrFromList.length, 2)
+      assert.equal(arrFromList[0], 1)
+      assert.equal(arrFromList[1], 2)
+    })
+  })
+
+  describe('filter', () => {
+    const newList = new LinkedList([1, 2]) as LinkedList<number>
+    const filteredList = newList.filter(node => node.data < 2)
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const unfilteredList = newList.filter(node => true)
+
+    it('returns a new LinkedList', () => {
+      assert.isTrue(filteredList instanceof LinkedList)
+      assert.notDeepEqual(newList, unfilteredList)
+    })
+
+    it('returns a LinkedList with the correct properties', () => {
+      assert.equal(filteredList.size, 1)
+      assert.equal(filteredList.at(0)?.data, 1)
+    })
+  })
+
+  describe('includes', () => {
+    const refObject = {prop: true}
+    const objectsList = new LinkedList([refObject])
+
+    const numbersList = new LinkedList([1, 2, 3])
+
+    it('correctly identifies the presence of primitives', () => {
+      assert.isTrue(numbersList.includes(1))
+      assert.isTrue(numbersList.includes(2))
+      assert.isTrue(numbersList.includes(3))
+
+      assert.isFalse(numbersList.includes(0))
+      assert.isFalse(numbersList.includes(4))
+    })
+
+    it('correctly identifies the presence of a strictly equal object', () => {
+      assert.isTrue(objectsList.includes(refObject))
+    })
+
+    it('does not identify the presence of a loosely equal', () => {
+      assert.isFalse(objectsList.includes({prop: true}))
+    })
+  })
+
+  describe('slice', () => {
+    const newList = new LinkedList([1, 2, 3, 4])
+
+    const subset1 = newList.slice(0)
+    const subset2 = newList.slice(1)
+    const subset3 = newList.slice(1, 2)
+    const subset4 = newList.slice(-1)
+    const subset5 = newList.slice(-3, -1)
+
+    const emptyList1 = newList.slice(4)
+    const emptyList2 = newList.slice(-1, -2)
+    const emptyList3 = newList.slice(2, 1)
+
+    it('returns a subset list with the expected properties', () => {
+      assert.isTrue(subset1 instanceof LinkedList)
+      assert.equal(subset1.size, 4)
+
+      assert.equal(subset2.size, 3)
+
+      assert.equal(subset3.size, 1)
+      assert.equal(subset3.head?.data, 2)
+
+      assert.equal(subset4.size, 1)
+      assert.equal(subset4.tail?.data, 4)
+
+      assert.equal(subset5.size, 2)
+      assert.equal(subset5.head?.data, 2)
+      assert.equal(subset5.tail?.data, 3)
+    })
+
+    it('with invalid params, returns an empty list', () => {
+      assert.equal(emptyList1.size, 0)
+      assert.equal(emptyList2.size, 0)
+      assert.equal(emptyList3.size, 0)
     })
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "lib": ["ES5","ES6","ES2015","ES7","ES2016","ES2017","ES2018","ESNext", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "downlevelIteration": true
+  }
+}


### PR DESCRIPTION
 ## What?

This commit updates lists to be iterable and refactors the constructor to accept an iterable

This commit also renames existing methods and adds some more methods to fill out the feature set to match linked list implementations in other languages as well as provide some Array like methods

## How? 

Methods have been refactored, some have been renamed, others added.

Iteration is now provided in a few different ways: Incidentally through the [IteratableIterator interface](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols), the Filter and forEach methods utilize a wrapped `iterate` method, and as before - custom iteration can be done by accessing the Node's `next` and `previous` methods per usual.

## Why?

The constructor refactor prevents mutations to existing list and nodes. Instantiation logic is much simpler and more ergonomic. Implementing the iteration interface allows for greater flexibility for users (eg `for..of` loops and spread operator).

Additional methods and method refactors provide useful functionality as well as conveniences that other developers will be familiar with

## Testing

This commit includes regression tests that confirm the existing list and its nodes are not mutated

Existing tests have been updated to account for refactoring changes and correct errors. Some tests have been removed when no longer needed

I've renamed the listFactory function in test for clarity